### PR TITLE
fixes:#83 Scroll to the contests

### DIFF
--- a/client/src/components/IndividualCard.jsx
+++ b/client/src/components/IndividualCard.jsx
@@ -98,7 +98,7 @@ function IndividualCard() {
       </Helmet>
       <div className="individualContestOuter">
         <div style={{ width: "75%" }}>
-          <Link to="/contests">
+          <Link to="newHead" smooth={true} duration={500}>
             <svg
               xmlns="http://www.w3.org/2000/svg"
               width="45"

--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -45,7 +45,7 @@ function Navbar() {
         </div>
 
         <div className={`nav-link  ${isMenuActive ? 'active' : ''}`}>
-          <Link to="/contests" className='link'>
+          <Link to="newHead" smooth={true} duration={500} className='link'>
             <li onClick={()=>toggleActive()} className='contents'>Contests</li>
           </Link>
           <Link to="https://github.com/pranshugupta54/digitomize"className='link' >


### PR DESCRIPTION
fixes:#83
# Description

-first when the (go to all contest) button goes to /contest  on main page and also the (contest) button on home page also does the same 
-now it shows all contests ,all available contest

Fixes #83

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## screeshot
![Screenshot (16)](https://github.com/pranshugupta54/digitomize/assets/120769092/6e5b4b18-e808-485f-b64c-b00f2110e047)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

---
- New Feature: Updated navigation in the `IndividualCard` and `Navbar` components. The links now smoothly scroll to the new section, enhancing user experience.
  - The link in `IndividualCard` now points to "newHead" instead of "/contests".
  - The `Navbar` component has been updated with two changes:
    - The first link now points to "newHead" instead of "/contests".
    - The second link now directs users to an external URL.
  - Both links have been enhanced with smooth scrolling functionality that completes in 500 milliseconds.
---
<!-- end of auto-generated comment: release notes by coderabbit.ai -->