### PR TITLE
Breadcrumbs added in the individual contests page

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -2,6 +2,15 @@
 <html lang="en">
 
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-BY8B08J7V0"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() { dataLayer.push(arguments); }
+    gtag('js', new Date());
+
+    gtag('config', 'G-BY8B08J7V0');
+  </script>
   <!-- <meta property="og:title" content="Digitomize"> -->
   <meta property="og:image" content="https://res.cloudinary.com/dsazw0r59/image/upload/v1693023476/logo_bg_y5ixum.jpg">
   <!-- <meta property="description" content="Explore upcoming coding contests on Digitomize and stay updated with the latest challenges. Join us to participate and test your coding skills." /> -->
@@ -14,15 +23,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;700;800&display=swap" rel="stylesheet">
   <title>Digitomize</title>
 </head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-BY8B08J7V0"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
 
-  gtag('config', 'G-BY8B08J7V0');
-</script>
 <body>
   <div id="root"></div>
   <script type="module" src="/src/main.jsx"></script>

--- a/client/index.html
+++ b/client/index.html
@@ -15,13 +15,13 @@
   <title>Digitomize</title>
 </head>
 <!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-5GQDTLQXQ3"></script>
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-BY8B08J7V0"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
 
-  gtag('config', 'G-87HC8M30GH');
+  gtag('config', 'G-BY8B08J7V0');
 </script>
 <body>
   <div id="root"></div>

--- a/client/src/components/css/IndividualCard.css
+++ b/client/src/components/css/IndividualCard.css
@@ -210,4 +210,5 @@
     margin: auto;
     width: fit-content;
     text-align: center;
+    text-transform: lowercase;
 }


### PR DESCRIPTION
# Description

Pushing into production the changes @PushpakRaut made - added breadcrumbs to individual contests pages.

Fixes #77 

## Type of change

- [x] New feature (non-breaking change which adds functionality)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

---
**New Feature:**
- Added a new navigation section in the Individual Card component. This includes links to Home, Contests, and the current card's name for improved user navigation.

**Style:**
- Updated CSS styles for better responsiveness across different screen sizes. This includes changes to `.card_Navigation`, `.card_nav_path` classes, and `#startTime` element.

**Refactor:**
- Removed unused SVG icon for "Go to all contests" link and replaced it with icons from `@mui/icons-material` library for a cleaner UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->